### PR TITLE
SetUp json product list

### DIFF
--- a/products/facade.py
+++ b/products/facade.py
@@ -1,0 +1,50 @@
+from products.models import CustomCoeficiente, CustomCoeficienteItens
+
+
+def get_partner_prices(parceiro, produtos):
+    partner_prices = []
+    try:
+        custom_coeficiente = CustomCoeficiente.objects.get(parceiro=parceiro)
+        custom_prices = CustomCoeficienteItens.objects.all().filter(
+            parceiro=custom_coeficiente
+        )
+        parceiro_coeficiente = custom_coeficiente.coeficiente_padrao
+
+        for produto in produtos:
+            try:
+                c_price = custom_prices.filter(produto__codigo=produto.codigo).values(
+                    "coeficiente"
+                )[0]["coeficiente"]
+                if c_price:
+                    produto.cliente_paga = round(
+                        produto.cliente_paga() + (produto.cliente_paga() * c_price),
+                        ndigits=2,
+                    )
+                    produto.coeficiente = c_price
+            except IndexError:
+                produto.cliente_paga = round(
+                    produto.cliente_paga()
+                    + (produto.cliente_paga() * parceiro_coeficiente),
+                    ndigits=2,
+                )
+            partner_prices.append(
+                {
+                    "codigo": produto.codigo,
+                    "descricao": produto.descricao,
+                    "estoque": produto.active,
+                    "valor": produto.cliente_paga,
+                }
+            )
+
+    except CustomCoeficiente.DoesNotExist:
+        for produto in produtos:
+            partner_prices.append(
+                {
+                    "codigo": produto.codigo,
+                    "descricao": produto.descricao,
+                    "estoque": produto.active,
+                    "valor": produto.cliente_paga(),
+                }
+            )
+
+    return partner_prices

--- a/products/tests/tests.py
+++ b/products/tests/tests.py
@@ -278,6 +278,30 @@ class ProductsTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'TYL-1080')
 
+    def test_product_list_json_view_anonimo(self):
+        self.client.logout()
+        response = self.client.get(reverse('product_list_json'))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, '/accounts/login/?next=/products/json/',
+                             status_code=302, target_status_code=200)
+
+    def test_product_list_json_view_parceiro(self):
+        self.client.force_login(self.user_parceiro)
+        response = self.client.get(reverse('product_list_json'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'TYL-1080')
+        self.assertContains(response, '1739.61')
+
+    def test_product_list_json_viewgerente(self):
+        self.client.force_login(self.user_gerente)
+        response = self.client.get(reverse('product_list_json'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'TYL-1080')
+        self.assertContains(response, '1199.73')
+
     @responses.activate
     def test_product_create(self):
         dir_path = os.path.dirname(os.path.realpath(__file__))

--- a/products/urls.py
+++ b/products/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     path('product/<str:codigo>/', views.product_view, name='product_view'),
     path('product/create/<str:codigo>/', views.product_create, name='product_create'),
     path('product/update/<str:codigo>/', views.product_update, name='product_update'),
+    path('json/', views.product_list_json, name='product_list_json'),
 ]

--- a/products/views.py
+++ b/products/views.py
@@ -1,12 +1,14 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.forms.models import inlineformset_factory
+from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.shortcuts import render
 from pybling.products import get_product
 
 from core.models import UserProfile, User
 from pedidos.models import Pedido, PedidoItem
+from .facade import get_partner_prices
 from .forms import ProdutoForm, ProdutoAtacadoForm
 from .models import Produto, CustomCoeficiente, CustomCoeficienteItens, ProdutoAtacado
 
@@ -155,6 +157,17 @@ def product_add(request):
         return redirect('product_create', codigo=codigo)
 
     return render(request, 'products/add.html')
+
+
+@login_required
+def product_list_json(request):
+    parceiro = User.objects.get(username=request.user)
+    produtos = Produto.objects.all().order_by('descricao')
+
+    partner_prices = get_partner_prices(parceiro, produtos)
+
+    data = {"results": partner_prices}
+    return JsonResponse(data)
 
 
 @login_required

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ cloudinary==1.22.0
 dj3-cloudinary-storage==0.0.3
 idna==2.10
 mock==4.0.2
-pbr==5.5.0
+pbr==5.5.1
 requests==2.24.0
 six==1.15.0
 urllib3==1.25.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,6 @@ exclude =
     dist,
     venv
 count = False
-ignore = E226,E302,E41
+ignore = E226,E302,E41,W503
 max-line-length = 119
 statistics = True


### PR DESCRIPTION
- Configura uma nova view e url para listagem de produtos em `json`
- Atualiza dependencia `pbr: 5.5.0 ==> 5.5.1`

Foi criado uma `fachada` para melhorar as views, que deve ser refatorado usando esse exemplo para as outras listagens.

> Obs.: ver `TODOs` em `products/views.py`

Está relacionado a Issue #498